### PR TITLE
#158048240: Personality Profile Presenter, Refactoring

### DIFF
--- a/app/presenters/personality_profile_presenter.rb
+++ b/app/presenters/personality_profile_presenter.rb
@@ -24,7 +24,7 @@ class PersonalityProfilePresenter
   end
 
   def total_tweets_analyzed
-    timeline_data.user_timeline.count
+    timeline_data.total_tweets
   end
 
   def oldest_tweet_analyzed

--- a/app/presenters/personality_profile_presenter.rb
+++ b/app/presenters/personality_profile_presenter.rb
@@ -39,17 +39,27 @@ class PersonalityProfilePresenter
     personality_data.warning_message
   end
 
+  def valid?
+    return true unless personality_data.error_message
+  end
+
+  def error_message
+    personality_data.error_message unless valid?
+  end
+
   def dimensions
-    personality_data.profile.dimensions
+    valid? ? profile.dimensions : nil
   end
 
   def needs
-    personality_data.profile.needs
+    valid? ? profile.needs : nil
   end
 
   def values
-    personality_data.profile.values
+    valid? ? profile.values : nil
   end
+
+
 
   private
     attr_reader :username
@@ -65,4 +75,9 @@ class PersonalityProfilePresenter
     def personality_data
       @personality_data ||= PersonalityInsightsSearch.new(username, timeline_data.to_string)
     end
+
+    def profile
+      personality_data.profile
+    end
+
 end

--- a/app/search/personality_insights_search.rb
+++ b/app/search/personality_insights_search.rb
@@ -5,7 +5,7 @@ class PersonalityInsightsSearch
   end
 
   def profile
-    PersonalityInsightsProfile.new(profile) unless error_message
+    PersonalityInsightsProfile.new(profile_info) unless error_message
   end
 
   def warning_message

--- a/app/search/personality_insights_search.rb
+++ b/app/search/personality_insights_search.rb
@@ -5,33 +5,45 @@ class PersonalityInsightsSearch
   end
 
   def profile
-    connection = Faraday.new("https://gateway.watsonplatform.net/personality-insights/api/v3/profile?version=2017-10-13") do | faraday |
-      faraday.request :multipart
-      faraday.response :logger
-      faraday.adapter :net_http
-      faraday.basic_auth(ENV["watson_username"], ENV["watson_password"])
-    end
+    PersonalityInsightsProfile.new(profile) unless error_message
+  end
 
-    response = connection.post do | req |
-      req.headers["Authorization"]
-      req.headers["Content-Type"]  = "text/plain;charset=utf-8"
-      req.headers["Accept"]        = "application/json"
-      req.body                     = data
-      # req.body                     = Faraday::UploadIO.new("./db/data/#{generate_file}.txt", 'plain/text')
-    end
+  def warning_message
+    profile_info[:message]
+  end
 
-    info = JSON.parse(response.body, symbolize_names: true)
-
-    info[:error] ? info[:error] : PersonalityInsightsProfile.new(info)
+  def error_message
+    profile_info[:error]
   end
 
   private
     attr_reader :username, :data
 
-    
+    def connection
+      Faraday.new("https://gateway.watsonplatform.net/personality-insights/api/v3/profile?version=2017-10-13") do | faraday |
+        faraday.request :multipart
+        faraday.response :logger
+        faraday.adapter :net_http
+        faraday.basic_auth(ENV["watson_username"], ENV["watson_password"])
+      end
+    end
+
+    def response
+      @response ||= connection.post do | req |
+        req.headers["Authorization"]
+        req.headers["Content-Type"]  = "text/plain;charset=utf-8"
+        req.headers["Accept"]        = "application/json"
+        req.body                     = data
+      end
+    end
+
+    def profile_info
+      JSON.parse(response.body, symbolize_names: true)
+    end
 
 
 
+    # req.body                   = Faraday::UploadIO.new("./db/data/#{generate_file}.txt", 'plain/text')
 
     # def generate_file(text = data)
     #   File.open("db/data/#{generate_file_name}.txt", 'w') { |file| file.write(text) }

--- a/app/views/personality_profile/show.html.erb
+++ b/app/views/personality_profile/show.html.erb
@@ -13,6 +13,13 @@
     </ul>
   </section>
   <section class="profile-right">
+    <% if @personality_profile.warning_message %>
+    <section class="warning">
+      <div class="message">
+        <%= @personality_profile.warning_message %>
+      </div>
+    </section>
+    <% end %>
     <div class="user-stats">
       <div class="counts">
         <div class="user-stat">
@@ -41,6 +48,7 @@
         </div>
       </div>
     </div>
+    <% if @personality_profile.valid? %>
     <section class="personality-profile">
       <div class="profile-header">
         Dimensions of Personality
@@ -104,5 +112,12 @@
         </div>
       </div>
     </section>
+    <% else %>
+    <section class="error">
+      <div class="message">
+        <%= @personality_profile.error_message %>
+      </div>
+    </section>
+    <% end %>
   </section>
 <main>

--- a/spec/search/twitter_timeline_search_spec.rb
+++ b/spec/search/twitter_timeline_search_spec.rb
@@ -7,13 +7,11 @@ describe TwitterTimelineSearch do
   end
 
   describe 'instance methods' do
-    describe '#user_timeline' do
-      it 'returns an array of hashes of users most recent statuses excluding retweets (max 3,200 including retweets)' do
+    describe '#total_tweets' do
+      it 'returns an integer corresponding to the number of tweets in the timeline' do
         VCR.use_cassette("twitter-timeline-search-user-timeline") do
-          expect(subject.user_timeline).to be_an Array
-          expect(subject.user_timeline.count).to eq(886)
-          expect(subject.user_timeline.first[:date]).to be_a String
-          expect(subject.user_timeline.first[:text]).to be_a String
+          expect(subject.total_tweets).to be_an Integer
+          expect(subject.total_tweets).to eq(886)
         end
       end
     end


### PR DESCRIPTION
- Add presenter for personality profile view (single interface to gather data from the various endpoints required to construct the personalty profile view)
- Adds TwitterUserTimeline#error_message and TwitterUserTimeline#warning_message (for cases in which the subject of a personality profile query has zero or too few tweets)
- Adds method to check whether Watson Personality Insights call returns hash with error message before generating profile objects
- Move connection, response, and JSON parse method in PersonalityProfileSearch to private methods
- Add warning and error message to view, along with conditional logic to generate divs according to whether they are present in the Watson response
- Refactor