### PR TITLE
Display saved text input profiles

### DIFF
--- a/app/views/saved_profiles/show.html.erb
+++ b/app/views/saved_profiles/show.html.erb
@@ -1,4 +1,21 @@
-<%= render partial: 'layouts/twitter_user_basic_info' %>
+
+<% if @personality_profile.username.nil? %>
+  <%= render partial: 'layouts/from_text_basic_info' %>
+  <div class="sidepanel-buttons">
+    <%= link_to "Return to Dashboard", dashboard_path, class: "btn sidepanel-button-btn" %>
+    <% unless @personality_profile.error_message %>
+      <%= link_to "Delete Profile and Return to Dashboard", "#{request.path}", method: :delete, class: "btn sidepanel-button-btn", data: {confirm: "Are you sure you want to delete this profile? You can generate a new profile for this Twitter user, but the data may have since changed."} %>
+    <% end %>
+  </div>
+  <% if @personality_profile.is_valid? %>
+    <%= cache "saved-personality-profile-#{@personality_profile.name.split(' ').join}-#{@personality_profile.updated_at}" do %>
+      <%= render partial: 'layouts/valid_profile_from_text' %>
+    <% end %>
+  <% else %>
+    <%= render partial: 'layouts/invalid_profile_from_text' %>
+  <% end %>
+<% else %>
+  <%= render partial: 'layouts/twitter_user_basic_info' %>
   <div class="sidepanel-buttons">
     <%= link_to "Return to Dashboard", dashboard_path, class: "btn sidepanel-button-btn" %>
     <% unless @personality_profile.error_message %>
@@ -12,3 +29,4 @@
   <% else %>
     <%= render partial: 'layouts/invalid_profile' %>
   <% end %>
+<% end %>

--- a/app/views/saved_profiles/show.html.erb
+++ b/app/views/saved_profiles/show.html.erb
@@ -4,7 +4,7 @@
   <div class="sidepanel-buttons">
     <%= link_to "Return to Dashboard", dashboard_path, class: "btn sidepanel-button-btn" %>
     <% unless @personality_profile.error_message %>
-      <%= link_to "Delete Profile and Return to Dashboard", "#{request.path}", method: :delete, class: "btn sidepanel-button-btn", data: {confirm: "Are you sure you want to delete this profile? You can generate a new profile for this Twitter user, but the data may have since changed."} %>
+      <%= link_to "Delete Profile and Return to Dashboard", "#{request.path}", method: :delete, class: "btn sidepanel-button-btn", data: {confirm: "Are you sure you want to delete this profile?"} %>
     <% end %>
   </div>
   <% if @personality_profile.is_valid? %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -32,7 +32,7 @@
       <div class="learn-more-instruction">
         <i class="far fa-file-alt"></i>
         <h3>GENERATE</h3>
-        <p>Generate a detailed Personality Profile based on an individual's Twitter timeline or, alternatively, by submitting text from non-Twitter source such as a cover letter or blog post. The text, excluding re-Tweets and replies when using timeline data, is passed to IBM's Personal Insights service, which makes meaningful and scientifically-based inferences about the individuals personality. The output is a report of how the individual ranks on a percentile-basis according to over 50 characteristics and facets of personality.</div>
+        <p>Generate a detailed Personality Profile based on an individual's Twitter timeline or, alternatively, by submitting text from non-Twitter source such as a cover letter or blog post. The text, excluding re-Tweets and replies when using timeline data, is passed to IBM's Personal Insights service, which makes meaningful and scientifically-based inferences about the individual's personality. The output is a report of how the individual ranks on a percentile-basis according to over 50 characteristics and facets of personality.</div>
       <div class="learn-more-divider">
         <i class="far fa-circle"></i>
       </div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -32,7 +32,7 @@
       <div class="learn-more-instruction">
         <i class="far fa-file-alt"></i>
         <h3>GENERATE</h3>
-        <p>Generate a detailed Personality Profile based on an individual's Twitter timeline, or by pasting and submitting text from non-Twitter source (e.g. cover letter, blog, etc.). The text, excluding re-Tweets and replies when using timeline data, is passed to IBM's Personal Insights service, which makes meaningful and scientifically-based inferences about the individuals personality. The output is a report of how the individual ranks on a percentile-basis according to over 50 characteristics and facets of personality.</div>
+        <p>Generate a detailed Personality Profile based on an individual's Twitter timeline or, alternatively, by submitting text from non-Twitter source such as a cover letter or blog post. The text, excluding re-Tweets and replies when using timeline data, is passed to IBM's Personal Insights service, which makes meaningful and scientifically-based inferences about the individuals personality. The output is a report of how the individual ranks on a percentile-basis according to over 50 characteristics and facets of personality.</div>
       <div class="learn-more-divider">
         <i class="far fa-circle"></i>
       </div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -32,7 +32,7 @@
       <div class="learn-more-instruction">
         <i class="far fa-file-alt"></i>
         <h3>GENERATE</h3>
-        <p>Generate a detailed Personality Profile for the user based on their Twitter timeline. Text data (excluding re-Tweets and replies) is passed to IBM's Personal Insights service, which makes meaningful and scientifically-based inferences about the individuals personality. The output is a report of how the individual ranks on a percentile-basis according to over 50 characteristics and facets of personality.</div>
+        <p>Generate a detailed Personality Profile based on an individual's Twitter timeline, or by pasting and submitting text from non-Twitter source (e.g. cover letter, blog, etc.). The text, excluding re-Tweets and replies when using timeline data, is passed to IBM's Personal Insights service, which makes meaningful and scientifically-based inferences about the individuals personality. The output is a report of how the individual ranks on a percentile-basis according to over 50 characteristics and facets of personality.</div>
       <div class="learn-more-divider">
         <i class="far fa-circle"></i>
       </div>

--- a/spec/features/user_can_save_a_personality_profile_generated_from_text.rb
+++ b/spec/features/user_can_save_a_personality_profile_generated_from_text.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+context 'User' do
+  let(:user) { create(:user) }
+  context 'can save a personality profile that they have generated from text' do
+    it 'and see the personality profile on their dashboard' do
+      VCR.use_cassette('personality_profile_from_text') do
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+        name   = 'Name'
+        source = 'Cover Letter'
+        text   = Faker::Lorem.sentence(1_500)
+
+        visit new_personality_profile_text_path
+
+        fill_in :name, with: name
+        fill_in :source, with: source
+        fill_in :text, with: text
+        click_on 'Submit'
+
+        click_on "Save Profile and Return to Dashboard"
+
+        expect(current_path).to eq('/dashboard')
+        expect(page).to have_content('Profile saved successfully')
+
+        within('.list-results') do
+          expect(page).to have_content(name)
+          expect(page).to have_content(source)
+          expect(page).to have_button('Delete')
+        end
+      end
+    end
+  end
+end

--- a/spec/features/user_can_view_saved_personality_profile_generated_from_text.rb
+++ b/spec/features/user_can_view_saved_personality_profile_generated_from_text.rb
@@ -5,9 +5,12 @@ context 'User' do
   context 'can save a personality profile that they have generated from text' do
     it 'and see the personality profile on their dashboard' do
       VCR.use_cassette('saved_personality_profile_from_text') do
-        user = create(:user, id: 1)
-        profile = create(:personality_profile, name: 'Nicholas Cage', username: nil, total_tweets_analyzed: nil, newest_tweet_analyzed_date: nil, oldest_tweet_analyzed_date: nil)
-        create(:dimension); create(:facet); create(:need); create(:value)
+        user      = create(:user, id: 1)
+        profile   = create(:personality_profile, name: 'Nicholas Cage', username: nil, total_tweets_analyzed: nil, newest_tweet_analyzed_date: nil, oldest_tweet_analyzed_date: nil)
+        dimension = create(:dimension)
+        facet     = create(:facet)
+        need      = create(:need)
+        value     = create(:value)
         saved_profile = create(:saved_profile, user_id: 1)
 
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
@@ -16,7 +19,18 @@ context 'User' do
 
         click_on "#{profile.name}"
 
+
         expect(current_path).to eq("/saved-profiles/#{saved_profile.id}")
+
+        expect(page).to have_content(profile.name)
+        expect(page).to have_content(profile.source)
+        expect(page).to have_content(profile.word_count)
+
+        expect(page).to have_content("Dimensions and Facets of Personality")
+        expect(page).to have_content(dimension.name)
+        expect(page).to have_content(facet.name)
+        expect(page).to have_content(need.name)
+        expect(page).to have_content(value.name)
       end
     end
   end

--- a/spec/features/user_can_view_saved_personality_profile_generated_from_text.rb
+++ b/spec/features/user_can_view_saved_personality_profile_generated_from_text.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+context 'User' do
+  let(:user) { create(:user) }
+  context 'can save a personality profile that they have generated from text' do
+    it 'and see the personality profile on their dashboard' do
+      VCR.use_cassette('saved_personality_profile_from_text') do
+        user = create(:user, id: 1)
+        profile = create(:personality_profile, name: 'Nicholas Cage', username: nil, total_tweets_analyzed: nil, newest_tweet_analyzed_date: nil, oldest_tweet_analyzed_date: nil)
+        create(:dimension); create(:facet); create(:need); create(:value)
+        saved_profile = create(:saved_profile, user_id: 1)
+
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+        visit '/dashboard'
+
+        click_on "#{profile.name}"
+
+        expect(current_path).to eq("/saved-profiles/#{saved_profile.id}")
+      end
+    end
+  end
+end

--- a/spec/features/user_cannot_save_personality_profile_that_had_insufficient_text_for_analysis.rb
+++ b/spec/features/user_cannot_save_personality_profile_that_had_insufficient_text_for_analysis.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+context 'User' do
+  let(:user) { create(:user) }
+  context 'attempts to generate a personality profile with insufficient text' do
+    it 'and does not have the option to save the profile' do
+      VCR.use_cassette('invalid_personality_profile_from_text') do
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+        name   = 'Name'
+        source = 'Cover Letter'
+        text   = Faker::Lorem.sentence(1)
+
+        visit new_personality_profile_text_path
+
+        fill_in :name, with: name
+        fill_in :source, with: source
+        fill_in :text, with: text
+        click_on 'Submit'
+
+        expect(page).to_not have_content('Save Profile and Return to Dashboard')
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add logic to handle displaying saved profiles that have been generated from text input from non-Twitter sources
- Update landing page descriptions to include references to ability to generate and save profiles based on text input from non-Twitter sources
- Update saved profile list on dashboard to include source information
- Add and revise tests